### PR TITLE
Do not display "null" when values are set to null

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -213,7 +213,7 @@ $(document).ready(function(){
             });
             $('#profile').html(`
             <div class="col s12 m7">
-                <h4 class="header"><i class="small material-icons">account_box</i>${user.name}</h4>
+                <h4 class="header"><i class="small material-icons">account_box</i>${user.name || '-'}</h4>
                 <div class="card hoverable horizontal">
                 <div id="details" class="row container">
                 <div class="card-image col s12 m5">
@@ -222,9 +222,9 @@ $(document).ready(function(){
                 <div class="card-stacked col s12 m7">
                     <div class="card-content">
                     <div class="collection">
-                    <a target = "_blank" href="${user.html_url}" class="collection-item"><span class="badge">${user.bio}</span>Bio</a>
-                    <a target = "_blank" href="${user.html_url}" class="collection-item"><span class="badge">${user.company}</span>Company</a>
-                    <a target = "_blank" href="${user.html_url}" class="collection-item"><span class="badge">${user.location}</span>Location</a>
+                    <a target = "_blank" href="${user.html_url}" class="collection-item"><span class="badge">${user.bio || '-'}</span>Bio</a>
+                    <a target = "_blank" href="${user.html_url}" class="collection-item"><span class="badge">${user.company || '-'}</span>Company</a>
+                    <a target = "_blank" href="${user.html_url}" class="collection-item"><span class="badge">${user.location || '-'}</span>Location</a>
                     <a target = "_blank" href="${user.html_url}?tab=repositories" class="collection-item"><span class="new badge" data-badge-caption="">${user.public_repos}</span>Repos</a>
                     <a target = "_blank" href="https://gist.github.com/${user.login}" class="collection-item"><span class="new badge" data-badge-caption="">${user.public_gists}</span>Gists</a>
                     <a target = "_blank" href="${user.html_url}?tab=followers" class="collection-item"><span class="new badge" data-badge-caption="">${user.followers}</span>Followers</a>

--- a/js/main.js
+++ b/js/main.js
@@ -175,7 +175,7 @@ $(document).ready(function(){
                     let desc = repo.desciption;
                     if (desc==null)
                         desc = "";
-                    let lang = repo.language.toLowerCase();
+                    let lang = (repo.language || '').toLowerCase();
                     switch (lang){
                         case "html":
                             lang = "html5";
@@ -197,7 +197,7 @@ $(document).ready(function(){
                                         <a target = "_blank" href="https://github.com/${username}/${repo.name}/network/members" class="collection-item"><span class="new badge" data-badge-caption="">${repo.forks_count}</span>Forks</a>
                                         <a target = "_blank" href="https://github.com/${username}/${repo.name}/watchers" class="collection-item"><span class="new badge" data-badge-caption="">${repo.watchers_count}</span>Watchers</a>
                                         <a target = "_blank" href="https://github.com/${username}/${repo.name}/stargazers" class="collection-item"><span class="new badge" data-badge-caption="">${repo.stargazers_count}</span>Stars</a>
-                                        <a target = "_blank" href="https://github.com/${username}/${repo.name}" class="collection-item"><span class="badge"><i class="devicon-${lang}-plain colored"></i>${repo.language}</span>Language</a>
+                                        <a target = "_blank" href="https://github.com/${username}/${repo.name}" class="collection-item"><span class="badge">${lang && `<i class="devicon-${lang}-plain colored"></i>`}${repo.language || '-'}</span>Language</a>
                                         <a target = "_blank" href="https://github.com/${username}/${repo.name}" class="collection-item"><span class="new badge" data-badge-caption="">${repo.created_at.substring(0,10)}</span>Created</a>
                                         <a target = "_blank" href="https://github.com/${username}/${repo.name}" class="collection-item"><span class="new badge" data-badge-caption="">${repo.updated_at.substring(0,10)}</span>Last Updated</a>
                                     </div>


### PR DESCRIPTION
Do not display `null` when some values (language, username, user bio, company, location etc) are set to null but set a default value.

This fixes #41 